### PR TITLE
Add sha512, sha512_256, sha512_224, sha384

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,3 +1,4 @@
 include(":keccak")
 include(":sha256")
+include(":sha512")
 include(":ripemd160")

--- a/sha512/src/main/kotlin/org/komputing/khash/sha512/Sha384.kt
+++ b/sha512/src/main/kotlin/org/komputing/khash/sha512/Sha384.kt
@@ -1,0 +1,18 @@
+package org.komputing.khash.sha512
+
+object Sha384 {
+    private val H0 = longArrayOf(
+        -0x344462a23efa6128L,
+        0x629a292a367cd507L,
+        -0x6ea6fea5cf8f22e9L,
+        0x152fecd8f70e5939L,
+        0x67332667ffc00b31L,
+        -0x714bb57897a7eaefL,
+        -0x24f3d1f29b067059L,
+        0x47b5481dbefa4fa4L
+    )
+
+    fun digest(message: ByteArray): ByteArray {
+        return Sha512.digest(message, H0).sliceArray(0 until 48)
+    }
+}

--- a/sha512/src/main/kotlin/org/komputing/khash/sha512/Sha512.kt
+++ b/sha512/src/main/kotlin/org/komputing/khash/sha512/Sha512.kt
@@ -1,0 +1,263 @@
+package org.komputing.khash.sha512
+
+/**
+ * Digest Class for SHA-512.
+ * Original Java version at hhttps://github.com/trittimo/SHA512
+ */
+object Sha512 {
+
+    private var K = longArrayOf(
+        0x428A2F98D728AE22L,
+        0x7137449123EF65CDL,
+        -0x4a3f043013b2c4d1L,
+        -0x164a245a7e762444L,
+        0x3956C25BF348B538L,
+        0x59F111F1B605D019L,
+        -0x6dc07d5b50e6b065L,
+        -0x54e3a12a25927ee8L,
+        -0x27f855675cfcfdbeL,
+        0x12835B0145706FBEL,
+        0x243185BE4EE4B28CL,
+        0x550C7DC3D5FFB4E2L,
+        0x72BE5D74F27B896FL,
+        -0x7f214e01c4e9694fL,
+        -0x6423f958da38edcbL,
+        -0x3e640e8b3096d96cL,
+        -0x1b64963e610eb52eL,
+        -0x1041b879c7b0da1dL,
+        0x0FC19DC68B8CD5B5L,
+        0x240CA1CC77AC9C65L,
+        0x2DE92C6F592B0275L,
+        0x4A7484AA6EA6E483L,
+        0x5CB0A9DCBD41FBD4L,
+        0x76F988DA831153B5L,
+        -0x67c1aead11992055L,
+        -0x57ce3992d24bcdf0L,
+        -0x4ffcd8376704dec1L,
+        -0x40a680384110f11cL,
+        -0x391ff40cc257703eL,
+        -0x2a586eb86cf558dbL,
+        0x06CA6351E003826FL,
+        0x142929670A0E6E70L,
+        0x27B70A8546D22FFCL,
+        0x2E1B21385C26C926L,
+        0x4D2C6DFC5AC42AEDL,
+        0x53380D139D95B3DFL,
+        0x650A73548BAF63DEL,
+        0x766A0ABB3C77B2A8L,
+        -0x7e3d36d1b812511aL,
+        -0x6d8dd37aeb7dcac5L,
+        -0x5d40175eb30efc9cL,
+        -0x57e599b443bdcfffL,
+        -0x3db4748f2f07686fL,
+        -0x3893ae5cf9ab41d0L,
+        -0x2e6d17e62910ade8L,
+        -0x2966f9dbaa9a56f0L,
+        -0xbf1ca7aa88edfd6L,
+        0x106AA07032BBD1B8L,
+        0x19A4C116B8D2D0C8L,
+        0x1E376C085141AB53L,
+        0x2748774CDF8EEB99L,
+        0x34B0BCB5E19B48A8L,
+        0x391C0CB3C5C95A63L,
+        0x4ED8AA4AE3418ACBL,
+        0x5B9CCA4F7763E373L,
+        0x682E6FF3D6B2B8A3L,
+        0x748F82EE5DEFB2FCL,
+        0x78A5636F43172F60L,
+        -0x7b3787eb5e0f548eL,
+        -0x7338fdf7e59bc614L,
+        -0x6f410005dc9ce1d8L,
+        -0x5baf9314217d4217L,
+        -0x41065c084d3986ebL,
+        -0x398e870d1c8dacd5L,
+        -0x35d8c13115d99e64L,
+        -0x2e794738de3f3df9L,
+        -0x15258229321f14e2L,
+        -0xa82b08011912e88L,
+        0x06F067AA72176FBAL,
+        0x0A637DC5A2C898A6L,
+        0x113F9804BEF90DAEL,
+        0x1B710B35131C471BL,
+        0x28DB77F523047D84L,
+        0x32CAAB7B40C72493L,
+        0x3C9EBE0A15C9BEBCL,
+        0x431D67C49C100D4CL,
+        0x4CC5D4BECB3E42B6L,
+        0x597F299CFC657E2AL,
+        0x5FCB6FAB3AD6FAECL,
+        0x6C44198C4A475817L
+    )
+
+    private var H0 = longArrayOf(
+        0x6A09E667F3BCC908L, -0x4498517a7b3558c5L, 0x3C6EF372FE94F82BL, -0x5ab00ac5a0e2c90fL,
+        0x510E527FADE682D1L, -0x64fa9773d4c193e1L, 0x1F83D9ABFB41BD6BL, 0x5BE0CD19137E2179L
+    )
+
+    fun digest(input: ByteArray): ByteArray {
+        return digest(input, H0)
+    }
+
+    // Does the actual hash
+    internal fun digest(input: ByteArray, h0: LongArray): ByteArray {
+        // First pad the input to the correct length, adding the bits specified in the SHA algorithm
+        var input = input
+        input = padMessage(input)
+        // Break the padded input up into blocks
+        val blocks: Array<LongArray> = toBlocks(input)
+        // And get the expanded message blocks
+        val W: Array<LongArray> = calculateMessageBlocks(blocks)
+        // Set up the buffer which will eventually contain the final hash
+        // Initially, it's set to the constants provided as part of the algorithm
+        val buffer: LongArray = h0.clone()
+        // For every block
+        for (i in blocks.indices) { // a-h is set to the buffer initially
+            var a = buffer[0]
+            var b = buffer[1]
+            var c = buffer[2]
+            var d = buffer[3]
+            var e = buffer[4]
+            var f = buffer[5]
+            var g = buffer[6]
+            var h = buffer[7]
+            // Run 80 rounds of the SHA-512 compression function on a-h
+            for (j in 0..79) {
+                val t1: Long =
+                    h + bigSig1(e) + ch(e, f, g) + K[j] + W[i][j]
+                val t2: Long = bigSig0(a) + maj(a, b, c)
+                h = g
+                g = f
+                f = e
+                e = d + t1
+                d = c
+                c = b
+                b = a
+                a = t1 + t2
+            }
+            // After finishing the compression, save the state to the buffer
+            buffer[0] = a + buffer[0]
+            buffer[1] = b + buffer[1]
+            buffer[2] = c + buffer[2]
+            buffer[3] = d + buffer[3]
+            buffer[4] = e + buffer[4]
+            buffer[5] = f + buffer[5]
+            buffer[6] = g + buffer[6]
+            buffer[7] = h + buffer[7]
+        }
+        return buffer.foldIndexed(ByteArray(64)) { index, acc, value ->
+            val indexBytes = index * 8
+            acc[indexBytes + 0] = (value ushr 56).toByte()
+            acc[indexBytes + 1] = (value ushr 48).toByte()
+            acc[indexBytes + 2] = (value ushr 40).toByte()
+            acc[indexBytes + 3] = (value ushr 32).toByte()
+            acc[indexBytes + 4] = (value ushr 24).toByte()
+            acc[indexBytes + 5] = (value ushr 16).toByte()
+            acc[indexBytes + 6] = (value ushr 8).toByte()
+            acc[indexBytes + 7] = value.toByte()
+            acc
+        }
+    }
+
+    // Used in the compression function
+    private fun ch(x: Long, y: Long, z: Long): Long {
+        return x and y xor (x.inv() and z)
+    }
+
+    // Used in the compression function
+    private fun maj(x: Long, y: Long, z: Long): Long {
+        return x and y xor (x and z) xor (y and z)
+    }
+
+    // Used in the compression function
+    private fun rotate(x: Long, l: Int): Long {
+        return x ushr l or (x shl java.lang.Long.SIZE - l)
+    }
+
+    // Used in the compression function
+    // Sn = right rotate by n bits
+    // Rn = right shift by n bits
+    private fun bigSig0(x: Long): Long { // S28(x) ^ S34(x) ^ S39(x)
+        return rotate(x, 28) xor rotate(x, 34) xor rotate(x, 39)
+    }
+
+    // Used in the compression function
+    private fun bigSig1(x: Long): Long { // S14(x) ^ S18(x) ^ S41(x)
+        return rotate(x, 14) xor rotate(x, 18) xor rotate(x, 41)
+    }
+
+    // Used in the message schedule
+    private fun smallSig0(x: Long): Long { // S1(x) ^ S8(x) ^ R7(x)
+        return rotate(x, 1) xor rotate(x, 8) xor (x ushr 7)
+    }
+
+    // Used in the message schedule
+    private fun smallSig1(x: Long): Long { // S19(x) ^ S61(x) ^ R6(x)
+        return rotate(x, 19) xor rotate(x, 61) xor (x ushr 6)
+    }
+
+    // Pads the input byte array
+    private fun padMessage(input: ByteArray): ByteArray {
+        // Need to append at least 17 bytes (16 for length of the message, and 1 for the '1' bit)
+        // then fill with 0s until multiple of 128 bytes
+        var size = input.size + 17
+
+        val remainder = size % 128
+        if (remainder != 0) {
+            size += 128 - remainder
+        }
+        // The padded byte array
+        val out = ByteArray(size)
+        // Copy over the old stuff
+        for (i in input.indices) {
+            out[i] = input[i]
+        }
+        // Add the '1' bit
+        out[input.size] = 0x80.toByte()
+        // And put original length of input at the end of our padded input
+        val len = input.size * 8L
+        out[size - 1] = len.toByte()
+        out[size - 2] = (len ushr 8).toByte()
+        out[size - 3] = (len ushr 16).toByte()
+        out[size - 4] = (len ushr 24).toByte()
+        return out
+    }
+
+    // Converts the byte array input starting at index j into a long
+    private fun arrToLong(input: ByteArray, j: Int): Long {
+        var v: Long = 0
+        for (i in 0..7) {
+            v = (v shl 8) + input[i + j].toUByte().toLong()
+        }
+        return v
+    }
+
+    // Converts the byte array input into blocks of longs
+    private fun toBlocks(input: ByteArray): Array<LongArray> { // a block has: 1024 bits = 128 bytes = 16 longs
+        val blocks = Array(input.size / 128) {
+            val block = LongArray(16)
+            for (j in 0..15) { // Set the block value to the correct one
+                block[j] = arrToLong(input, it * 128 + j * 8)
+            }
+            block
+        }
+        return blocks
+    }
+
+    // Calculates the expanded message blocks W0-W79
+    private fun calculateMessageBlocks(M: Array<LongArray>): Array<LongArray> {
+        val W = Array(M.size) { LongArray(80) }
+        // For each block in the input
+        for (i in M.indices) {
+            // For each long in the block
+            for (j in 0..15) { // Set the initial values of W to be the value of the input directly
+                W[i][j] = M[i][j]
+            }
+            // For the rest of the values
+            for (j in 16..79) { // Do some math from the SHA512 algorithm
+                W[i][j] =
+                    smallSig1(W[i][j - 2]) + W[i][j - 7] + smallSig0(W[i][j - 15]) + W[i][j - 16]
+            }
+        }
+        return W
+    }
+}

--- a/sha512/src/main/kotlin/org/komputing/khash/sha512/Sha512_224.kt
+++ b/sha512/src/main/kotlin/org/komputing/khash/sha512/Sha512_224.kt
@@ -1,0 +1,19 @@
+package org.komputing.khash.sha512
+
+object Sha512_224 {
+    private val H0 = longArrayOf(
+        -0x73c2c837e6abb25eL,
+        0x73E1996689DCD4D6L,
+        0x1DFAB7AE32FF9C82L,
+        0x679DD514582F9FCFL,
+        0x0F6D2B697BD44DA8L,
+        0x77E36F7304C48942L,
+        0x3F9D85A86A1D36C8L,
+        0x1112E6AD91D692A1L
+    )
+
+
+    fun digest(message: ByteArray): ByteArray {
+        return Sha512.digest(message, H0).sliceArray(0 until 28)
+    }
+}

--- a/sha512/src/main/kotlin/org/komputing/khash/sha512/Sha512_256.kt
+++ b/sha512/src/main/kotlin/org/komputing/khash/sha512/Sha512_256.kt
@@ -1,0 +1,19 @@
+package org.komputing.khash.sha512
+
+object Sha512_256 {
+    private val H0 = longArrayOf(
+        0x22312194fc2bf72cL,
+        -0x60aaa05c37b39b3eL,
+        0x2393b86b6f53b151L,
+        -0x69c788e6a6bf1543L,
+        -0x69d7c11d5771001dL,
+        -0x41a1e1daac79c66eL,
+        0x2b0199fc2c85b8aaL,
+        0x0eb72ddc81c52ca2L
+    )
+
+
+    fun digest(message: ByteArray): ByteArray {
+        return Sha512.digest(message, H0).sliceArray(0 until 32)
+    }
+}

--- a/sha512/src/main/kotlin/org/komputing/khash/sha512/extensions/PublicExtensions.kt
+++ b/sha512/src/main/kotlin/org/komputing/khash/sha512/extensions/PublicExtensions.kt
@@ -1,0 +1,24 @@
+package org.komputing.khash.sha512.extensions
+
+import org.komputing.khash.sha512.Sha512
+
+/**
+ * Returns the SHA512 digest of this byte array.
+ */
+fun ByteArray.sha512() = Sha512.digest(this)
+
+/**
+ * Returns the SHA512 digest of this string.
+ */
+fun String.sha512() = this.toByteArray(Charsets.UTF_8).sha512()
+
+/**
+*
+*/
+fun LongArray.toHexString(): String {
+    var result = ""
+    for (i in 0..7) {
+        result += java.lang.String.format("%016x", this[i])
+    }
+    return result
+}

--- a/sha512/src/main/kotlin/org/komputing/khash/sha512/extensions/PublicExtensions.kt
+++ b/sha512/src/main/kotlin/org/komputing/khash/sha512/extensions/PublicExtensions.kt
@@ -11,14 +11,3 @@ fun ByteArray.sha512() = Sha512.digest(this)
  * Returns the SHA512 digest of this string.
  */
 fun String.sha512() = this.toByteArray(Charsets.UTF_8).sha512()
-
-/**
-*
-*/
-fun LongArray.toHexString(): String {
-    var result = ""
-    for (i in 0..7) {
-        result += java.lang.String.format("%016x", this[i])
-    }
-    return result
-}

--- a/sha512/src/test/kotlin/org/komputing/khash/sha512/Sha384Tests.kt
+++ b/sha512/src/test/kotlin/org/komputing/khash/sha512/Sha384Tests.kt
@@ -1,0 +1,50 @@
+package org.komputing.khash.sha512
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.walleth.khex.toNoPrefixHexString
+
+class Sha384Tests {
+
+    @Test
+    fun testDigest1() {
+        testHash(
+            "".toByteArray(),
+            "38b060a751ac96384cd9327eb1b1e36a21fdb71114be07434c0cc7bf63f6e1da274edebfe76f65fbd51ad2f14898b95b"
+        )
+    }
+
+    @Test
+    fun testDigest2() {
+        testHash(
+            "Hello world!".toByteArray(),
+            "86255fa2c36e4b30969eae17dc34c772cbebdfc58b58403900be87614eb1a34b8780263f255eb5e65ca9bbb8641cccfe"
+        )
+    }
+
+    @Test
+    fun testDigest3() {
+        val loremIpsum = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. " +
+                "Proin pulvinar turpis purus, sit amet dapibus magna commodo quis metus."
+        testHash(
+            loremIpsum.toByteArray(),
+            "bd2143a9952d27a18331aa3632a01331531ffec2a4ff351a5859706ebdb39068b34553ac81f83f1bc6b1b16f31c06e2b"
+        )
+    }
+
+    private fun testHash(input: ByteArray, expected: String) {
+        assertEquals(expected, Sha384.digest(input).toNoPrefixHexString())
+    }
+
+    @Test
+    fun testHashRawBytes() {
+        val b = ByteArray(256)
+        for (i in b.indices) {
+            b[i] = i.toByte()
+        }
+        testHash(
+            b,
+            "ffdaebff65ed05cf400f0221c4ccfb4b2104fb6a51f87e40be6c4309386bfdec2892e9179b34632331a59592737db5c5"
+        )
+    }
+}

--- a/sha512/src/test/kotlin/org/komputing/khash/sha512/Sha512Tests.kt
+++ b/sha512/src/test/kotlin/org/komputing/khash/sha512/Sha512Tests.kt
@@ -1,0 +1,50 @@
+package org.komputing.khash.sha512
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.walleth.khex.toNoPrefixHexString
+
+class Sha512Tests {
+
+    @Test
+    fun testDigest1() {
+        testHash(
+            "".toByteArray(),
+            "cf83e1357eefb8bdf1542850d66d8007d620e4050b5715dc83f4a921d36ce9ce47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e"
+        )
+    }
+
+    @Test
+    fun testDigest2() {
+        testHash(
+            "Hello world!".toByteArray(),
+            "f6cde2a0f819314cdde55fc227d8d7dae3d28cc556222a0a8ad66d91ccad4aad6094f517a2182360c9aacf6a3dc323162cb6fd8cdffedb0fe038f55e85ffb5b6"
+        )
+    }
+
+    @Test
+    fun testDigest3() {
+        val loremIpsum = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. " +
+                "Proin pulvinar turpis purus, sit amet dapibus magna commodo quis metus."
+        testHash(
+            loremIpsum.toByteArray(),
+            "de94877cc9711605dcdc09d85bd3080f74398d5e1ad8f0dcd1726c54ac93f2b4b781c3f56de1fbc725ac261a2c09d1d5bb24d0afa7449e4ffe4b2a7e6d09f40d"
+        )
+    }
+
+    private fun testHash(input: ByteArray, expected: String) {
+        assertEquals(expected, Sha512.digest(input).toNoPrefixHexString())
+    }
+
+    @Test
+    fun testHashRawBytes() {
+        val b = ByteArray(256)
+        for (i in b.indices) {
+            b[i] = i.toByte()
+        }
+        testHash(
+            b,
+            "1e7b80bc8edc552c8feeb2780e111477e5bc70465fac1a77b29b35980c3f0ce4a036a6c9462036824bd56801e62af7e9feba5c22ed8a5af877bf7de117dcac6d"
+        )
+    }
+}

--- a/sha512/src/test/kotlin/org/komputing/khash/sha512/Sha512_224Tests.kt
+++ b/sha512/src/test/kotlin/org/komputing/khash/sha512/Sha512_224Tests.kt
@@ -1,0 +1,47 @@
+package org.komputing.khash.sha512
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.walleth.khex.toNoPrefixHexString
+
+class Sha512_224Tests {
+
+    @Test
+    fun testDigest1() {
+        testHash(
+            "".toByteArray(),
+            "6ed0dd02806fa89e25de060c19d3ac86cabb87d6a0ddd05c333b84f4"
+        )
+    }
+
+    @Test
+    fun testDigest2() {
+        testHash(
+            "Hello world!".toByteArray(),
+            "b48c4994a3d2b6b48ae7fa6fcc09f33dc0c985109c0b7493fd3c74d0"
+        )
+    }
+
+    @Test
+    fun testDigest3() {
+        val loremIpsum = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. " +
+                "Proin pulvinar turpis purus, sit amet dapibus magna commodo quis metus."
+        testHash(
+            loremIpsum.toByteArray(),
+            "09c63e3a2e822c8477b192da10afa757824ba057d9996b823ad08656"
+        )
+    }
+
+    private fun testHash(input: ByteArray, expected: String) {
+        assertEquals(expected, Sha512_224.digest(input).toNoPrefixHexString())
+    }
+
+    @Test
+    fun testHashRawBytes() {
+        val b = ByteArray(255)
+        for (i in b.indices) {
+            b[i] = i.toByte()
+        }
+        testHash(b, "9e31b671e498e8160ba558aafacd05defd252b2c7d8ba8e9e618fbf1")
+    }
+}

--- a/sha512/src/test/kotlin/org/komputing/khash/sha512/Sha512_256Tests.kt
+++ b/sha512/src/test/kotlin/org/komputing/khash/sha512/Sha512_256Tests.kt
@@ -1,0 +1,47 @@
+package org.komputing.khash.sha512
+
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+import org.walleth.khex.toNoPrefixHexString
+
+class Sha512_256Tests {
+
+    @Test
+    fun testDigest1() {
+        testHash(
+            "".toByteArray(),
+            "c672b8d1ef56ed28ab87c3622c5114069bdd3ad7b8f9737498d0c01ecef0967a"
+        )
+    }
+
+    @Test
+    fun testDigest2() {
+        testHash(
+            "Hello world!".toByteArray(),
+            "f8162ad49196c1c12bddbcff1d362ddacf03ae246b6a7864b75c244b965fe475"
+        )
+    }
+
+    @Test
+    fun testDigest3() {
+        val loremIpsum = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. " +
+                "Proin pulvinar turpis purus, sit amet dapibus magna commodo quis metus."
+        testHash(
+            loremIpsum.toByteArray(),
+            "3e4d6734eb5ea2195a818833ad47bd3be83320bc4619e076a9cc21028e0dfd7e"
+        )
+    }
+
+    private fun testHash(input: ByteArray, expected: String) {
+        assertEquals(expected, Sha512_256.digest(input).toNoPrefixHexString())
+    }
+
+    @Test
+    fun testHashRawBytes() {
+        val b = ByteArray(255)
+        for (i in b.indices) {
+            b[i] = i.toByte()
+        }
+        testHash(b, "fd932614f375bf71420530a690cb16e52c08e99cfe741ac8436fca8c8bfd5676")
+    }
+}


### PR DESCRIPTION
This adds the hash functions sha512, sha512_256, sha512_224, sha384 as specified on https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf and based on the java version at https://github.com/trittimo/SHA512
